### PR TITLE
MAKEFILE - Remove unnecesary make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,6 @@ PHP_VER ?= 7.1
 BEHAT ?= "vendor/bin/behat"
 BEHAT_YML ?= "tests/behat/behat.yml"
 
-test:
-	cd ./test/$(DRUPAL_VER) && PHP_VER=$(PHP_VER) ./run
-
 behat:
 	docker-compose exec -u www-data -T php ${BEHAT} --config ${BEHAT_YML} --colors $(params)
 


### PR DESCRIPTION
Test command is a command from docker4drupal that does not do anything in our boilerplay.