### PR TITLE
Typo on drush.yml

### DIFF
--- a/drush/drush.yml
+++ b/drush/drush.yml
@@ -8,7 +8,7 @@ drush:
   paths:
     # Load a drush.yml configuration file from the current working directory.
     config:
-      - web/sites/defaut/local.drush.yml
+      - web/sites/default/local.drush.yml
 command:
   sql:
     dump:


### PR DESCRIPTION
We have a minor typo on drush: paths: config: name.
defaut --> default
Cheers