### PR TITLE
Load ui_patterns_field_formatters from drupal instead of GIT.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,6 @@
         {
             "type": "vcs",
             "url": "https://git.drupalcode.org/sandbox/desarrollo2.0-3097360.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/pdureau/ui_patterns_field_formatters.git"
         }
     ],
     "require": {
@@ -68,7 +64,7 @@
         "drupal/simple_sitemap": "^2.11",
         "drupal/stage_file_proxy": "^1.0",
         "drupal/styleguide": "^1.0@alpha",
-        "drupal/ui_patterns_field_formatters": "dev-master",
+        "drupal/ui_patterns_field_formatters": "^1.0",
         "drupal/ui_patterns_settings": "^1.0",
         "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/webform": "^5.0@beta",


### PR DESCRIPTION
Lately, the drupal-boilerplate is failing because of this error:

```sh
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package drupal/ui_patterns_field_formatters dev-master exists as drupal/ui_patterns_field_formatters[dev-1.x, 1.x-dev, 1.0.0, 1.1.0, 1.2.0, dev-8.x-1.x] but these are rejected by your constraint.
```

This is because the ui_patterns_field_formatters module is now a stable Drupal module instead of a git repo, and (I guess) the maintainer has deleted the original GIT repo or renamed the branches we were loading.

The following PR solves this by simply loading the module from Drupal and using version numbers.

Please note this is just to fix the issue. Another equally valid solution would be to drop the ui_pattern dependencies from the composer.json file at all.