### PR TITLE
Comment SSH_AUTH_SOCK

### DIFF
--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -5,8 +5,8 @@ services:
   # @NOTE: enable ssh_auth_sock environment and volume variables
   # in the case you need to access to remote servers
   # inside docker using self-hosted credentials. It only works on Linux.
-  php:
-    environment:
+#  php:
+#    environment:
 #      SSH_AUTH_SOCK: /ssh-agent
 #      # Read instructions at https://wodby.com/docs/stacks/php/local/#xdebug
 #      PHP_XDEBUG: 1
@@ -18,7 +18,7 @@ services:
 #      PHP_XDEBUG_CLIENT_HOST: 10.254.254.254 # macOS, Docker < 18.03
 #      PHP_XDEBUG_CLIENT_HOST: 10.0.75.1 # Windows, Docker < 18.03
 #      PHP_XDEBUG_LOG: /tmp/php-xdebug.log
-    volumes:
+#    volumes:
 #      - $SSH_AUTH_SOCK:/ssh-agent
 ## For XHProf and Xdebug profiler traces
 #      - files:/mnt/files

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -18,7 +18,7 @@ services:
 #      PHP_XDEBUG_CLIENT_HOST: 10.0.75.1 # Windows, Docker < 18.03
 #      PHP_XDEBUG_LOG: /tmp/php-xdebug.log
     volumes:
-      - $SSH_AUTH_SOCK:/ssh-agent
+#      - $SSH_AUTH_SOCK:/ssh-agent
 ## For XHProf and Xdebug profiler traces
 #      - files:/mnt/files
 ## Alternative for macOS users: Mutagen https://wodby.com/docs/stacks/drupal/local#docker-for-mac

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -2,11 +2,12 @@ version: "3.7"
 
 services:
 
-  # @NOTE: ssh_auth_sock configuration only works for linux,
-  # uncomment if you have problems.
+  # @NOTE: enable ssh_auth_sock environment and volume variables
+  # in the case you need to access to remote servers
+  # inside docker using self-hosted credentials. It only works on Linux.
   php:
     environment:
-      SSH_AUTH_SOCK: /ssh-agent
+#      SSH_AUTH_SOCK: /ssh-agent
 #      # Read instructions at https://wodby.com/docs/stacks/php/local/#xdebug
 #      PHP_XDEBUG: 1
 #      PHP_XDEBUG_MODE: debug

--- a/readme.md
+++ b/readme.md
@@ -281,3 +281,12 @@ Note that WEB_SERVER_PORT is the local machine port which is mapped to point the
 3. Start containers running `docker-compose up -d` in repository root.
 4. To access the site go to URL: http://\<PROJECT_BASE_URL\>:\<WEBSERVER_PORT\>/
 5. To access the project's documentation go to URL: http://docs.\<PROJECT_BASE_URL\>:\<WEBSERVER_PORT\>/
+6. (Optional) In the case you need access to remote environments inside PHP container, uncomment these lines at docker-compose.override.yml:
+```yaml
+#  php:
+#    environment:
+#      SSH_AUTH_SOCK: /ssh-agent
+...
+#    volumes:
+#      - $SSH_AUTH_SOCK:/ssh-agent
+```


### PR DESCRIPTION
`SSH_AUTH_SOCK` variable should be commented because it  may crash in some operative system. Example: arch linux based distributions like Manjaro. I've only seen this working on Debian-based distributions. This could be problematic on `composer create-project` command, as it will crash 

Plus, the ability of accesing remote servers with your self private is not always required. Such an example, in my personal project I don't want use this variable because I don't want update my local environment with any remote environment.