### PR TITLE
Make dev dependencies compatible with PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ node_modules/
 
 # Ensure .gitkeep files are commited so folder structure get respected.
 !.gitkeep
+/.editorconfig
+/.gitattributes

--- a/composer.json
+++ b/composer.json
@@ -56,14 +56,13 @@
         "jcalderonzumba/gastonjs": "^1.2",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.3",
         "metadrop/behat-contexts": "dev-fb-nuvoleweb-dev-i45-behat-4.x",
-        "metadrop/grumphp-drupal-check": "~0.1",
+        "metadrop/grumphp-drupal-check": "^0.3.0",
         "metadrop/scripthor": "1.x-dev",
-        "mglaman/drupal-check": "^1.1",
+        "mglaman/drupal-check": "^1.1.8",
         "mikey179/vfsstream": "^1.6",
         "pdepend/pdepend": "^2.8",
         "phpmd/phpmd": "^2.9",
-        "sebastian/phpcpd": "^5.0",
-        "vijaycs85/drupal-quality-checker": "^1.3.0"
+        "phpro/grumphp": "^1.3.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "drupal/admin_toolbar": "^2.4",
         "drupal/config_split": "^1.7",
         "drupal/core-composer-scaffold": "^9",
-        "drupal/core-recommended": "^9",
+        "drupal/core-recommended": "^9.1",
         "drupal/environment_indicator": "^4.0",
         "drupal/eu_cookie_compliance": "^1.13",
         "drupal/honeypot": "^2.0",

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,13 @@
 /INSTALL.txt
 /README.txt
 /example.gitignore
+/.csslintrc
+/.eslintignore
+/.eslintrc.json
+/.ht.router.php
+/.htaccess
+/README.md
+/autoload.php
+/index.php
+/update.php
+/web.config

--- a/web/modules/.gitignore
+++ b/web/modules/.gitignore
@@ -1,0 +1,1 @@
+/README.txt

--- a/web/profiles/.gitignore
+++ b/web/profiles/.gitignore
@@ -1,0 +1,1 @@
+/README.txt

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -45,17 +45,17 @@ Disallow: /comment/reply/
 Disallow: /filter/tips
 Disallow: /node/add/
 Disallow: /search/
-Disallow: /user/register/
-Disallow: /user/password/
-Disallow: /user/login/
-Disallow: /user/logout/
+Disallow: /user/register
+Disallow: /user/password
+Disallow: /user/login
+Disallow: /user/logout
 # Paths (no clean URLs)
 Disallow: /index.php/admin/
 Disallow: /index.php/comment/reply/
 Disallow: /index.php/filter/tips
 Disallow: /index.php/node/add/
 Disallow: /index.php/search/
-Disallow: /index.php/user/password/
-Disallow: /index.php/user/register/
-Disallow: /index.php/user/login/
-Disallow: /index.php/user/logout/
+Disallow: /index.php/user/password
+Disallow: /index.php/user/register
+Disallow: /index.php/user/login
+Disallow: /index.php/user/logout

--- a/web/sites/.gitignore
+++ b/web/sites/.gitignore
@@ -1,0 +1,2 @@
+/README.txt
+/example.settings.local.php

--- a/web/sites/default/.gitignore
+++ b/web/sites/default/.gitignore
@@ -1,0 +1,1 @@
+/default.settings.php

--- a/web/sites/default/default.services.yml
+++ b/web/sites/default/default.services.yml
@@ -118,7 +118,8 @@ parameters:
   # Cacheability debugging:
   #
   # Responses with cacheability metadata (CacheableResponseInterface instances)
-  # get X-Drupal-Cache-Tags and X-Drupal-Cache-Contexts headers.
+  # get X-Drupal-Cache-Tags, X-Drupal-Cache-Contexts and X-Drupal-Cache-Max-Age
+  # headers.
   #
   # For more information about debugging cacheable responses, see
   # https://www.drupal.org/developing/api/8/response/cacheable-response-interface
@@ -126,15 +127,13 @@ parameters:
   # Not recommended in production environments
   # @default false
   http.response.debug_cacheability_headers: false
-  factory.keyvalue:
-    {}
+  factory.keyvalue: {}
     # Default key/value storage service to use.
     # @default keyvalue.database
     # default: keyvalue.database
     # Collection-specific overrides.
     # state: keyvalue.database
-  factory.keyvalue.expirable:
-    {}
+  factory.keyvalue.expirable: {}
     # Default key/value expirable storage service to use.
     # @default keyvalue.database.expirable
     # default: keyvalue.database.expirable

--- a/web/themes/.gitignore
+++ b/web/themes/.gitignore
@@ -1,0 +1,1 @@
+/README.txt


### PR DESCRIPTION
After applying this pull request the project won't have any composer restrictions to use PHP 8. It will let us check if the project is compatible with PHP 8.