### PR TITLE
Make dev dependencies compatible with PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,7 @@
         "metadrop/scripthor": "1.x-dev",
         "mikey179/vfsstream": "^1.6",
         "pdepend/pdepend": "^2.8",
-        "phpmd/phpmd": "^2.9",
-        "phpro/grumphp": "^1.3.0"
+        "phpmd/phpmd": "^2.9"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -56,14 +56,13 @@
         "jcalderonzumba/gastonjs": "^1.2",
         "jcalderonzumba/mink-phantomjs-driver": "^0.3.3",
         "metadrop/behat-contexts": "dev-fb-nuvoleweb-dev-i45-behat-4.x",
-        "metadrop/grumphp-drupal-check": "~0.1",
+        "metadrop/grumphp-drupal-check": "^0.3.0",
         "metadrop/scripthor": "1.x-dev",
-        "mglaman/drupal-check": "^1.1",
+        "mglaman/drupal-check": "^1.1.8",
         "mikey179/vfsstream": "^1.6",
         "pdepend/pdepend": "^2.8",
         "phpmd/phpmd": "^2.9",
-        "sebastian/phpcpd": "^5.0",
-        "vijaycs85/drupal-quality-checker": "^1.3.0"
+        "phpro/grumphp": "^1.3.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
         "metadrop/behat-contexts": "dev-fb-nuvoleweb-dev-i45-behat-4.x",
         "metadrop/grumphp-drupal-check": "^0.3.0",
         "metadrop/scripthor": "1.x-dev",
-        "mglaman/drupal-check": "^1.1.8",
         "mikey179/vfsstream": "^1.6",
         "pdepend/pdepend": "^2.8",
         "phpmd/phpmd": "^2.9",

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,18 +1,9 @@
-parameters:
-  git_hook_variables:
-    EXEC_GRUMPHP_COMMAND: docker-compose exec -T php
+grumphp:
   extensions:
     - GrumphpDrupalCheck\ExtensionLoader
-  ascii:
-    failed: vendor/vijaycs85/drupal-quality-checker/resources/ascii/grumpy.txt
-    succeeded: vendor/vijaycs85/drupal-quality-checker/resources/ascii/happy.txt
-  git_dir: .
-  bin_dir: vendor/bin
+  hooks_dir: ~
+  hooks_preset: local
   tasks:
-    git_commit_message:
-      enforce_no_subject_trailing_period: true
-      max_subject_width: 130
-      case_insensitive: false
     phplint: ~
     yamllint: ~
     composer: ~
@@ -40,7 +31,5 @@ parameters:
         - feature
         - info
         - txt
-        - md
-        - js
         - test
       standard: Drupal,DrupalPractice

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -36,4 +36,6 @@ grumphp:
         - info
         - txt
         - test
+        - md
+        - js
       standard: Drupal,DrupalPractice

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -35,7 +35,7 @@ grumphp:
         - feature
         - info
         - txt
-        - test
         - md
         - js
+        - test
       standard: Drupal,DrupalPractice

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,7 +2,6 @@ grumphp:
   extensions:
     - GrumphpDrupalCheck\ExtensionLoader
   hooks_dir: ~
-  hooks_preset: local
   tasks:
     git_commit_message:
       enforce_no_subject_trailing_period: true

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -4,6 +4,10 @@ grumphp:
   hooks_dir: ~
   hooks_preset: local
   tasks:
+    git_commit_message:
+      enforce_no_subject_trailing_period: true
+      max_subject_width: 130
+      case_insensitive: false
     phplint: ~
     yamllint: ~
     composer: ~

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,4 +1,6 @@
 grumphp:
+  git_hook_variables:
+    EXEC_GRUMPHP_COMMAND: docker-compose exec -T php
   extensions:
     - GrumphpDrupalCheck\ExtensionLoader
   hooks_dir: ~


### PR DESCRIPTION
After applying this pull request the project won't have any composer restrictions to use PHP 8. It will let us check if the project is compatible with PHP 8.