### PR TITLE
GRUMPHP - Allow it to run without needing to start PHP container

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,6 @@
 grumphp:
   git_hook_variables:
-    EXEC_GRUMPHP_COMMAND: docker-compose exec -T php
+    EXEC_GRUMPHP_COMMAND: docker-compose run --rm -T php
   extensions:
     - GrumphpDrupalCheck\ExtensionLoader
   hooks_dir: ~


### PR DESCRIPTION
If we use docker-compose run instead of docker-compose exec, it won't be needed to start php container. 
To prevent pollute the disk space, `--rm` parameter is used.