### PR TITLE
TEST - Add access tests and refactor

### DIFF
--- a/tests/behat/features/content/article_access.feature
+++ b/tests/behat/features/content/article_access.feature
@@ -4,11 +4,11 @@ Feature: As a system
 
   Background:
     Given "article" content:
-      | title                           | status       |
-      | Behat article test published    | published    |
-      | Behat article test unpublished  | draft        |
+      | title                           | status   |
+      | Behat article test published    | 1        |
+      | Behat article test unpublished  | 0        |
 
-  @sunnyday @api @article @access @authenticated @anonymous @exclude
+  @sunnyday @api @article @access @authenticated @anonymous
   Scenario Outline: Simple article access by moderation state
     Given I am a user with <role> role
 
@@ -35,7 +35,7 @@ Feature: As a system
       | anonymous      |
       | authenticated  |
 
-  @sunnyday @api @article @access @editor @manager @exclude
+  @sunnyday @api @article @access @administrator
   Scenario Outline: Simple article access by moderation state (administrative roles)
     Given I am a user with <role> role
 

--- a/tests/behat/features/content/article_access.feature
+++ b/tests/behat/features/content/article_access.feature
@@ -1,0 +1,82 @@
+Feature: As a system
+  I want to protect Article access per moderation state
+  So that only published content is accessible to not privileged users
+
+  Background:
+    Given "article" content:
+      | title                           | moderation_state |
+      | Behat article test published    | published        |
+      | Behat article test draft        | draft            |
+      | Behat article test archived     | archived         |
+      | Behat article test unpublished  | unpublished      |
+
+  @sunnyday @api @article @access @authenticated @anonymous @energies
+  Scenario Outline: Simple article access by moderation state
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test published"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    Examples:
+      | role           |
+      | anonymous      |
+      | authenticated  |
+
+  @sunnyday @api @article @access @editor @manager @energies
+  Scenario Outline: Simple article access by moderation state (administrative roles)
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    Examples:
+      | role           |
+      | administrator  |

--- a/tests/behat/features/content/article_access.feature
+++ b/tests/behat/features/content/article_access.feature
@@ -1,45 +1,31 @@
 Feature: As a system
-  I want to protect Article access per moderation state
+  I want to protect Article access per status
   So that only published content is accessible to not privileged users
 
   Background:
     Given "article" content:
-      | title                           | moderation_state |
-      | Behat article test published    | published        |
-      | Behat article test draft        | draft            |
-      | Behat article test archived     | archived         |
-      | Behat article test unpublished  | unpublished      |
+      | title                           | status       |
+      | Behat article test published    | published    |
+      | Behat article test unpublished  | draft        |
 
-  @sunnyday @api @article @access @authenticated @anonymous @energies
+  @sunnyday @api @article @access @authenticated @anonymous @exclude
   Scenario Outline: Simple article access by moderation state
     Given I am a user with <role> role
 
     # View:
     When I go to the "node" entity with label "Behat article test published"
     Then the response status code should be 200
-    When I go to the "node" entity with label "Behat article test draft"
-    Then the response status code should be 403
-    When I go to the "node" entity with label "Behat article test archived"
-    Then the response status code should be 403
     When I go to the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 403
 
     # Edit:
     When I go to "edit" of the "node" entity with label "Behat article test published"
     Then the response status code should be 403
-    When I go to "edit" of the "node" entity with label "Behat article test draft"
-    Then the response status code should be 403
-    When I go to "edit" of the "node" entity with label "Behat article test archived"
-    Then the response status code should be 403
     When I go to "edit" of the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 403
 
     # Delete:
     When I go to "delete" of the "node" entity with label "Behat article test published"
-    Then the response status code should be 403
-    When I go to "delete" of the "node" entity with label "Behat article test draft"
-    Then the response status code should be 403
-    When I go to "delete" of the "node" entity with label "Behat article test archived"
     Then the response status code should be 403
     When I go to "delete" of the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 403
@@ -49,31 +35,19 @@ Feature: As a system
       | anonymous      |
       | authenticated  |
 
-  @sunnyday @api @article @access @editor @manager @energies
+  @sunnyday @api @article @access @editor @manager @exclude
   Scenario Outline: Simple article access by moderation state (administrative roles)
     Given I am a user with <role> role
 
     # View:
-    When I go to the "node" entity with label "Behat article test draft"
-    Then the response status code should be 200
-    When I go to the "node" entity with label "Behat article test archived"
-    Then the response status code should be 200
     When I go to the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 200
 
     # Edit:
-    When I go to "edit" of the "node" entity with label "Behat article test draft"
-    Then the response status code should be 200
-    When I go to "edit" of the "node" entity with label "Behat article test archived"
-    Then the response status code should be 200
     When I go to "edit" of the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 200
 
     # Delete:
-    When I go to "delete" of the "node" entity with label "Behat article test draft"
-    Then the response status code should be 200
-    When I go to "delete" of the "node" entity with label "Behat article test archived"
-    Then the response status code should be 200
     When I go to "delete" of the "node" entity with label "Behat article test unpublished"
     Then the response status code should be 200
 

--- a/tests/behat/features/content/article_access.moderation_state.feature.example
+++ b/tests/behat/features/content/article_access.moderation_state.feature.example
@@ -1,0 +1,82 @@
+Feature: As a system
+  I want to protect Article access per moderation state
+  So that only published content is accessible to not privileged users
+
+  Background:
+    Given "article" content:
+      | title                           | moderation_state |
+      | Behat article test published    | published        |
+      | Behat article test draft        | draft            |
+      | Behat article test archived     | archived         |
+      | Behat article test unpublished  | unpublished      |
+
+  @sunnyday @api @article @access @authenticated @anonymous
+  Scenario Outline: Simple article access by moderation state
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test published"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    Examples:
+      | role           |
+      | anonymous      |
+      | authenticated  |
+
+  @sunnyday @api @article @access @administrator
+  Scenario Outline: Simple article access by moderation state (administrative roles)
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    Examples:
+      | role           |
+      | administrator  |

--- a/tests/behat/features/content/article_delete.feature
+++ b/tests/behat/features/content/article_delete.feature
@@ -20,15 +20,3 @@ Feature: As a user
     Examples:
       | role           |
       | administrator  |
-
-
-  @error @api @article @delete @authenticated @anonymous
-  Scenario Outline: Simple Article delete role access
-    Given I am a user with <role> role
-    When I go to "delete" of the "node" entity with label "Behat article test"
-    Then the response status code should be 403
-
-    Examples:
-      | role           |
-      | anonymous      |
-      | authenticated  |

--- a/tests/behat/features/content/article_edit.feature
+++ b/tests/behat/features/content/article_edit.feature
@@ -20,14 +20,3 @@ Feature: As a user
       | role           |
       | administrator  |
 
-
-  @error @api @article @edit @authenticated @anonymous
-  Scenario Outline: Simple Article edit role access
-    Given I am a user with <role> role
-    When I go to "edit" of the "node" entity with label "Behat article test"
-    Then the response status code should be 403
-
-    Examples:
-      | role           |
-      | anonymous      |
-      | authenticated  |

--- a/tests/behat/features/content/article_view.feature
+++ b/tests/behat/features/content/article_view.feature
@@ -4,7 +4,7 @@ Feature: As a user
 
   Background:
     Given "article" content:
-      | title           |
+      | title              |
       | Behat article test |
 
 

--- a/tests/behat/features/content/page_access.feature
+++ b/tests/behat/features/content/page_access.feature
@@ -5,9 +5,8 @@ Feature: As a system
   Background:
     Given "page" content:
       | title                        | status    |
-      | Behat page test published    | published |
-      | Behat page test unpublished  | draft     |
-
+      | Behat page test published    | 1         |
+      | Behat page test unpublished  | 0         |
 
   @sunnyday @api @page @access @authenticated @anonymous
   Scenario Outline: Simple Page access by moderation state

--- a/tests/behat/features/content/page_access.feature
+++ b/tests/behat/features/content/page_access.feature
@@ -4,42 +4,29 @@ Feature: As a system
 
   Background:
     Given "page" content:
-      | title                        | moderation_state |
-      | Behat page test published    | published        |
-      | Behat page test draft        | draft            |
-      | Behat page test archived     | archived         |
-      | Behat page test unpublished  | unpublished      |
+      | title                        | status    |
+      | Behat page test published    | published |
+      | Behat page test unpublished  | draft     |
 
-  @sunnyday @api @page @access @authenticated @anonymous @energies
+
+  @sunnyday @api @page @access @authenticated @anonymous
   Scenario Outline: Simple Page access by moderation state
     Given I am a user with <role> role
 
     # View:
     When I go to the "node" entity with label "Behat page test published"
     Then the response status code should be 200
-    When I go to the "node" entity with label "Behat page test draft"
-    Then the response status code should be 403
-    When I go to the "node" entity with label "Behat page test archived"
-    Then the response status code should be 403
     When I go to the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 403
 
     # Edit:
     When I go to "edit" of the "node" entity with label "Behat page test published"
     Then the response status code should be 403
-    When I go to "edit" of the "node" entity with label "Behat page test draft"
-    Then the response status code should be 403
-    When I go to "edit" of the "node" entity with label "Behat page test archived"
-    Then the response status code should be 403
     When I go to "edit" of the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 403
 
     # Delete:
     When I go to "delete" of the "node" entity with label "Behat page test published"
-    Then the response status code should be 403
-    When I go to "delete" of the "node" entity with label "Behat page test draft"
-    Then the response status code should be 403
-    When I go to "delete" of the "node" entity with label "Behat page test archived"
     Then the response status code should be 403
     When I go to "delete" of the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 403
@@ -49,31 +36,19 @@ Feature: As a system
       | anonymous      |
       | authenticated  |
 
-  @sunnyday @api @page @access @editor @manager @energies
+  @sunnyday @api @page @access @administrator
   Scenario Outline: Simple Page access by moderation state (administrative roles)
     Given I am a user with <role> role
 
     # View:
-    When I go to the "node" entity with label "Behat page test draft"
-    Then the response status code should be 200
-    When I go to the "node" entity with label "Behat page test archived"
-    Then the response status code should be 200
     When I go to the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 200
 
     # Edit:
-    When I go to "edit" of the "node" entity with label "Behat page test draft"
-    Then the response status code should be 200
-    When I go to "edit" of the "node" entity with label "Behat page test archived"
-    Then the response status code should be 200
     When I go to "edit" of the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 200
 
     # Delete:
-    When I go to "delete" of the "node" entity with label "Behat page test draft"
-    Then the response status code should be 200
-    When I go to "delete" of the "node" entity with label "Behat page test archived"
-    Then the response status code should be 200
     When I go to "delete" of the "node" entity with label "Behat page test unpublished"
     Then the response status code should be 200
 

--- a/tests/behat/features/content/page_access.feature
+++ b/tests/behat/features/content/page_access.feature
@@ -1,0 +1,82 @@
+Feature: As a system
+  I want to protect Page access per moderation state
+  So that only published content is accessible to not privileged users
+
+  Background:
+    Given "page" content:
+      | title                        | moderation_state |
+      | Behat page test published    | published        |
+      | Behat page test draft        | draft            |
+      | Behat page test archived     | archived         |
+      | Behat page test unpublished  | unpublished      |
+
+  @sunnyday @api @page @access @authenticated @anonymous @energies
+  Scenario Outline: Simple Page access by moderation state
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat page test published"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat page test draft"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat page test archived"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 403
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat page test published"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat page test draft"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat page test archived"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 403
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat page test published"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat page test draft"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat page test archived"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 403
+
+    Examples:
+      | role           |
+      | anonymous      |
+      | authenticated  |
+
+  @sunnyday @api @page @access @editor @manager @energies
+  Scenario Outline: Simple Page access by moderation state (administrative roles)
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat page test draft"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat page test archived"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 200
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat page test draft"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat page test archived"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 200
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat page test draft"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat page test archived"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat page test unpublished"
+    Then the response status code should be 200
+
+    Examples:
+      | role           |
+      | administrator  |

--- a/tests/behat/features/content/page_access.moderation_state.feature.example
+++ b/tests/behat/features/content/page_access.moderation_state.feature.example
@@ -1,0 +1,82 @@
+Feature: As a system
+  I want to protect Article access per moderation state
+  So that only published content is accessible to not privileged users
+
+  Background:
+    Given "article" content:
+      | title                           | moderation_state |
+      | Behat article test published    | published        |
+      | Behat article test draft        | draft            |
+      | Behat article test archived     | archived         |
+      | Behat article test unpublished  | unpublished      |
+
+  @sunnyday @api @article @access @authenticated @anonymous
+  Scenario Outline: Simple article access by moderation state
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test published"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test published"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 403
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 403
+
+    Examples:
+      | role           |
+      | anonymous      |
+      | authenticated  |
+
+  @sunnyday @api @article @access @administrator
+  Scenario Outline: Simple article access by moderation state (administrative roles)
+    Given I am a user with <role> role
+
+    # View:
+    When I go to the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Edit:
+    When I go to "edit" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "edit" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    # Delete:
+    When I go to "delete" of the "node" entity with label "Behat article test draft"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test archived"
+    Then the response status code should be 200
+    When I go to "delete" of the "node" entity with label "Behat article test unpublished"
+    Then the response status code should be 200
+
+    Examples:
+      | role           |
+      | administrator  |

--- a/tests/behat/features/content/page_delete.feature
+++ b/tests/behat/features/content/page_delete.feature
@@ -20,15 +20,3 @@ Feature: As a user
     Examples:
       | role           |
       | administrator  |
-
-
-  @error @api @page @delete @authenticated @anonymous
-  Scenario Outline: Simple Page delete role access
-    Given I am a user with <role> role
-    When I go to "delete" of the "node" entity with label "Behat page test"
-    Then the response status code should be 403
-
-    Examples:
-      | role           |
-      | anonymous      |
-      | authenticated  |

--- a/tests/behat/features/content/page_edit.feature
+++ b/tests/behat/features/content/page_edit.feature
@@ -19,15 +19,3 @@ Feature: As a user
     Examples:
       | role           |
       | administrator  |
-
-
-  @error @api @page @edit @authenticated @anonymous
-  Scenario Outline: Simple Page edit role access
-    Given I am a user with <role> role
-    When I go to "edit" of the "node" entity with label "Behat page test"
-    Then the response status code should be 403
-
-    Examples:
-      | role           |
-      | anonymous      |
-      | authenticated  |


### PR DESCRIPTION
Added test coverage to control access to different types of content depending on user role and content publishing status. 
Two types of tests have been added, those that depend on the moderation_state and other simpler ones that check the status (published and draft). 
This functionality has been deleted of the other tests to avoid duplication.