### PR TITLE
GRUMPHP - Git branch configuration

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -9,12 +9,14 @@ grumphp:
       enforce_no_subject_trailing_period: true
       max_subject_width: 130
       case_insensitive: false
+    # Adjust here the format that must have
+    # the git branch names of your project.
     git_branch_name:
       whitelist:
-        - "fb-[0-9A-Za-z\\s_-]*"
-        - "hf-[0-9A-Za-z\\s_-]*"
-        - "bf-[0-9A-Za-z\\s_-]*"
-        - "dev"
+        - "feature/[0-9A-Za-z\\s_-]*"
+        - "hotfix/[0-9A-Za-z\\s_-]*"
+        - "bugfix/[0-9A-Za-z\\s_-]*"
+        - "develop"
       blacklist:
         - "release"
         - "main"

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -17,7 +17,7 @@ grumphp:
         - "dev"
       blacklist:
         - "release"
-        - "master"
+        - "main"
       additional_modifiers: ''
       allow_detached_head: true
     phplint: ~

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -9,6 +9,17 @@ grumphp:
       enforce_no_subject_trailing_period: true
       max_subject_width: 130
       case_insensitive: false
+    git_branch_name:
+      whitelist:
+        - "fb-[0-9A-Za-z\\s_-]*"
+        - "hf-[0-9A-Za-z\\s_-]*"
+        - "bf-[0-9A-Za-z\\s_-]*"
+        - "dev"
+      blacklist:
+        - "release"
+        - "master"
+      additional_modifiers: ''
+      allow_detached_head: true
     phplint: ~
     yamllint: ~
     composer: ~


### PR DESCRIPTION
This pull request attempts to limit the branch names to the normal ones used in projects by [grumphp configuration](https://github.com/phpro/grumphp/blob/master/doc/tasks/git_branch_name.md).

It would allow to:

- Only create branches with common names: feature branches (fb), bug fixes (bf) and hotfixes (hf).
- Do not commit straight to sensitive branches as release or master, for that is better managing it  by doing merge / pull requests

Please check, thanks!