### PR TITLE
Update phpcs pattern to avoid skipping theme settings

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,6 +44,7 @@
   <exclude-pattern>*.ico</exclude-pattern>
   <exclude-pattern>*/settings.php</exclude-pattern>
   <exclude-pattern>*/*\.settings.php</exclude-pattern>
+  <exclude-pattern>*/settings\.*\.php</exclude-pattern>
 
 <!--
    After drupal/coder upgrade (in context of 8.7.11 security release) js static analysis started to fail.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -43,7 +43,7 @@
   <exclude-pattern>*.jpeg</exclude-pattern>
   <exclude-pattern>*.ico</exclude-pattern>
   <exclude-pattern>*/settings.php</exclude-pattern>
-  <exclude-pattern>*/*.settings.php</exclude-pattern>
+  <exclude-pattern>*/*\.settings.php</exclude-pattern>
 
 <!--
    After drupal/coder upgrade (in context of 8.7.11 security release) js static analysis started to fail.


### PR DESCRIPTION
I've realized that running `phpqa` resulted on a number of errors that didn't appear when running `phpcs` on its own.

This was happening because `phpcs` was skipping my `theme-settings.php` files that sit on Drupal themes, whereas `phpqa` was not.

I traced the origin to this pattern on `phpcs.xml.dist`:

`  <exclude-pattern>*/.settings.php</exclude-pattern>`

This seems to be excluding all files that _end with settings.php_, as the point (.) charecter seems to be understood as in regex, meaning "any character".

This rule should ideally be able to __skip__ `settings.local.php` or `local.settings.php` but __pass__ theme-settings.php.

For this, the point character needs to be escaped and a new rule should be added:

I propose to change the rules as follow:

```xml
<!-- Will exclude any settings.php -->
  <exclude-pattern>*/settings.php</exclude-pattern>
<!-- Will exclude anything that ends with *.settings.php, point is escaped -->
  <exclude-pattern>*/*\.settings.php</exclude-pattern>
<!-- Will exclude anything that follows the pattern settings.ANYTHING.php -->
  <exclude-pattern>*/settings\.*\.php</exclude-pattern>
```

