### PR TITLE
GRUMPHP - Add env variable to grumphp exec command to hide deprecation warnings

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,6 +1,6 @@
 grumphp:
   git_hook_variables:
-    EXEC_GRUMPHP_COMMAND: docker-compose run --rm -T php
+    EXEC_GRUMPHP_COMMAND: docker-compose run -e'PHP_ERROR_REPORTING=E_ALL & ~E_DEPRECATED' --rm -T php
   extensions:
     - GrumphpDrupalCheck\ExtensionLoader
   hooks_dir: ~


### PR DESCRIPTION
When the PHP version is set to 8.0/8.1, GrumPhp complains about deprecation with many warnings, messing up the console output. 

I propose to add an environment variable to hide Php deprecation warnings until we can update the grumphp. 