### PR TITLE
MAKEFILE - Make setup should reinit grumphp config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ setup:
 	docker-compose up -d
 	docker-compose exec -T php composer install
 	scripts/reload-local.sh --site=${DEFAULT_SITE_ALIAS}
+	docker-compose run -e'PHP_ERROR_REPORTING=E_ALL & ~E_DEPRECATED' --rm -T php 'vendor/bin/grumphp' 'git:init'
 
 ## setup-from-config	:	Prepares the site and installs it using the Drupal configuration files
 .PHONY: setup-from-config


### PR DESCRIPTION
Occasionally grumphp.yml gets modified, like when you need to alter the EXEC_GRUMPHP_COMMAND variable. In those cases, you have to warn your partners about the need to run the grumphp git:init command, because this change doesn't consolidate automatically on already existing projects. 

I propose to do this step automatically in every environment setup. Please note that I've added the environment variable to hide deprecation warnings in php8. This should be removed when grumphp can be updated.