### PR TITLE
Fixed backstopjs mount point so it's only mounted on docker-composer.override

### DIFF
--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -46,7 +46,9 @@ services:
       ADMINER_DEFAULT_DB_NAME: $DB_NAME
     labels:
       - "traefik.http.routers.${PROJECT_NAME}_adminer.rule=Host(`adminer.${PROJECT_BASE_URL}`)"
-
+  backstopjs:
+    volumes:
+      - ./tests/backstopjs:/src # User-guided caching
 #volumes:
 ## For macOS users (Mutagen)
 #  mutagen:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -314,8 +314,6 @@ services:
     image: backstopjs/backstopjs:${BACKSTOPJS_TAG}
     container_name: "${PROJECT_NAME}_backstop"
     working_dir: '/src'
-    volumes:
-      - ./tests/backstopjs:/src # User-guided caching
     entrypoint: []
     command: tail -F /dev/null
     user: node


### PR DESCRIPTION
Backstopjs test folder only need to be mounted in local environment, in CI test are copied to the docker container so there is not need to mount that directory.