### PR TITLE
Configuration of email sending after docker version update of wodby

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     image: wodby/drupal-php:$PHP_TAG
     container_name: "${PROJECT_NAME}_php"
     environment:
-      PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S mailhog:1025
-#      PHP_SENDMAIL_PATH: /usr/sbin/sendmail -t -i -S opensmtpd:25
+      SSMTP_MAILHUB: mailhog:1025
+#      SSMTP_MAILHUB: opensmtpd:25
+      PHP_SENDMAIL_PATH: '"/usr/bin/dos2unix -u | /usr/sbin/ssmtp -t -f"'
       DB_HOST: $DB_HOST
       DB_PORT: $DB_PORT
       DB_USER: $DB_USER


### PR DESCRIPTION
After updating the docker version of wodby it is also necessary to update the email sending configuration in the docker-compose.yml, otherwise the email sending will not work.
https://github.com/wodby/docker4drupal/blob/master/docker-compose.yml#L21