### PR TITLE
Upgrade Node version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,9 +82,9 @@ REDIS_TAG=6-3.4.9
 
 ### --- NODE ---
 
-NODE_TAG=14-dev-0.51.4
-#NODE_TAG=12-dev-0.51.4
-#NODE_TAG=10-dev-0.51.4
+NODE_TAG=18-dev-1.18.1
+#NODE_TAG=16-dev-1.18.1
+#NODE_TAG=14-dev-0.51.4
 
 ### --- VARNISH ---
 

--- a/.env.example
+++ b/.env.example
@@ -82,9 +82,9 @@ REDIS_TAG=6-3.4.9
 
 ### --- NODE ---
 
-NODE_TAG=18-dev-1.18.1
-#NODE_TAG=16-dev-1.18.1
+NODE_TAG=16-dev-1.18.1
 #NODE_TAG=14-dev-0.51.4
+#NODE_TAG=12-dev-0.51.4
 
 ### --- VARNISH ---
 


### PR DESCRIPTION
Issue #102 

### Problem
Currently, when installing the project for the first time or when launching a make frontend command once installed, the following error appears:

```bash
docker-compose exec -w "/var/www/html/web/themes/custom"/"boilerplate" node sh /var/www/html/scripts/frontend-build.sh dev 
Running ./scripts/frontend-build.sh dev 
npm ERR! code ENOTSUP 
npm ERR! notsup Unsupported engine for radix_subtheme@: wanted: {"npm":">=6.0","node":">=16.0","yarn":">=1.6"} (current: {"node":"14.15.4","npm":"6.14.10"
}) 
npm ERR! notsup Not compatible with your version of node/npm: radix_subtheme@ 
npm ERR! notsup Not compatible with your version of node/npm: radix_subtheme@ 
npm ERR! notsup Required: {"npm":">=6.0","node":">=16.0","yarn":">=1.6"} 
npm ERR! notsup Actual:  {"npm":"6.14.10","node":"14.15.4"} 
 
npm ERR! A complete log of this run can be found in: 
npm ERR!    /home/node/.npm/_logs/2023-02-14T10_15_52_197Z-debug.log 
ERROR: 1 
make: *** [Makefile:43: frontend] Error 1
```