### PR TITLE
Add allow-plugins to composer.json to make installation more agile on branch 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,16 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
-        "discard-changes": true
+        "discard-changes": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "cweagans/composer-patches": true,
+            "drupal/core-composer-scaffold": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true,
+            "phpro/grumphp": true,
+            "metadrop/scripthor": true
+        }
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold"


### PR DESCRIPTION
Fixes https://github.com/Metadrop/drupal-boilerplate/issues/115 for 3.x branch.