### PR TITLE
Use PHP 8.0 by default and provide updated PHP images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,16 +29,16 @@ MARIADB_TAG=10.5-3.10.0
 
 # Linux (uid 1000 gid 1000)
 
-PHP_TAG=7.4-dev-4.22.0
-#PHP_TAG=8.0-dev-4.22.0
-#PHP_TAG=7.3-dev-4.22.0
-#PHP_TAG=7.2-dev-4.22.0
+#PHP_TAG=8.2-dev-4.44.0
+#PHP_TAG=8.1-dev-4.44.0
+PHP_TAG=8.0-dev-4.44.0
+#PHP_TAG=7.4-dev-4.38.5
 
 # macOS (uid 501 gid 20)
 
-#PHP_TAG=8.0-dev-macos-4.22.0
-#PHP_TAG=7.4-dev-macos-4.22.0
-#PHP_TAG=7.3-dev-macos-4.22.0
+#PHP_TAG=8.2-dev-macos-4.44.0
+#PHP_TAG=8.1-dev-macos-4.44.0
+#PHP_TAG=8.0-dev-macos-4.44.0
 
 ### --- NGINX ----
 


### PR DESCRIPTION
Fixes https://github.com/Metadrop/drupal-boilerplate/issues/119