### PR TITLE
Remove phpcpd dependency

### DIFF
--- a/.phpqa.yml
+++ b/.phpqa.yml
@@ -8,7 +8,7 @@ phpqa:
   report: false
   execution: parallel
   output: file
-  tools: phpcs:0,phpmd:0,phpcpd:0,parallel-lint:0
+  tools: phpcs:0,phpmd:0,parallel-lint:0
   # array definition and allowed errors count is supported too
   # tools: [phploc, phpcs:0]
   verbose: false
@@ -31,11 +31,6 @@ phpmd:
   # alternatively you can use an array to define multiple rule sets (https://phpmd.org/documentation/index.html#using-multiple-rule-sets)
   standard: phpmd.xml.dist
 
-phpcpd:
-  minLines: 5
-  minTokens: 70
-  names: "*.php,*.module,*.install,*.theme,*.inc,*.profile"
-
 paralell-lint:
   reports:
     file:
@@ -47,5 +42,4 @@ paralell-lint:
 tool:
   phpcs: Edge\QA\Tools\Analyzer\Phpcs
   phpmd: Edge\QA\Tools\Analyzer\Phpmd
-  phpcpd: Edge\QA\Tools\Analyzer\Phpcpd
   parallel-lint: Edge\QA\Tools\Analyzer\ParallelLint

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
             "url": "https://packages.drupal.org/8"
         }
     ],
+    "replace": {
+        "sebastian/phpcpd": "*"
+    },
     "require": {
         "composer/installers": "^2.2",
         "cweagans/composer-patches": "^1.7",

--- a/docs/docs/boilerplate/grumphp.md
+++ b/docs/docs/boilerplate/grumphp.md
@@ -15,7 +15,6 @@ Grumphp is already configured (so you don't need to worry about that) making the
 - composer: Perform `composer.json` and `composer.lock` validation.
 - [jsonlint](https://github.com/Seldaek/jsonlint): Detects JSON files syntax errors.
 - [drupalcheck](https://github.com/mglaman/drupal-check): Check Drupal code for deprecations and discover bugs via static analysis.
-- [phpcpd](https://github.com/sebastianbergmann/phpcpd): Copy/paste detector to avoid duplicated code.
 - [phpcs](https://github.com/squizlabs/PHP_CodeSniffer): Check if your code accomplish the following standards:
     - Drupal: The [Drupal coding standards](https://www.drupal.org/docs/develop/standards/coding-standards).
     - DrupalPractice: Drupal best practices. @TODO: Is this in place?

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -46,20 +46,6 @@ grumphp:
     yamllint: ~
     composer: ~
     jsonlint: ~
-    phpcpd:
-      directory:
-        - ./web/**/custom
-      triggered_by:
-        - php
-        - inc
-        - module
-        - install
-        - profile
-        - theme
-        - feature
-        - info
-        - js
-        - test
     phpmd:
       exclude:
         - tests/

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Tools included out-of-the-box:
   - A boilerplate folder structure that fits all project needs.
   - A working and preconfigured Drush, the Drupal shell.
   - MkDocs to document your project using Markdown files.
-  - Grumphp to enforce [Drupal coding standards](https://www.drupal.org/docs/develop/standards/coding-standards). It is configured to use [phplint](https://github.com/overtrue/phplint), yamlint,  [jsonlint](https://github.com/Seldaek/jsonlint), [drupalcheck](https://github.com/mglaman/drupal-check), [phpcpd](https://github.com/sebastianbergmann/phpcpd) and [phpcs](https://github.com/squizlabs/PHP_CodeSniffer).
+  - Grumphp to enforce [Drupal coding standards](https://www.drupal.org/docs/develop/standards/coding-standards). It is configured to use [phplint](https://github.com/overtrue/phplint), yamlint,  [jsonlint](https://github.com/Seldaek/jsonlint), [drupalcheck](https://github.com/mglaman/drupal-check) and [phpcs](https://github.com/squizlabs/PHP_CodeSniffer).
   - Phpqa for static analysis.
   - Behat BDD testing configured and working.
   - PHPUnit for unit testing configured and working.


### PR DESCRIPTION
phpcpd is deprecated and composer already shows a warning that it must be replaced. As phpqa still requires it in its composer.json, until the Issue https://github.com/EdgedesignCZ/phpqa/issues/259 is resolved I propose to add a replace in the boilerplate composer and remove phpcpd from the grumphp and phpqa tests.