### PR TITLE
Remove version from docker as it is deprecated

### DIFF
--- a/docker-compose.ngrok.yml
+++ b/docker-compose.ngrok.yml
@@ -1,4 +1,3 @@
-version: "3.6"
 
 services:
 

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
 

--- a/docker-compose.xdebug.override.yml.dist
+++ b/docker-compose.xdebug.override.yml.dist
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
   mariadb:

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,4 +1,3 @@
-version: "3.6"
 
 syncs:
   docker-sync:


### PR DESCRIPTION
Warning:

> time="2024-03-22T08:03:03+01:00" level=warning msg="/var/lib/jenkins/workspace/schaer-schaer_tests_PR-462/docker-compose.yml: `version` is obsolete"
time="2024-03-22T08:03:03+01:00" level=warning msg="/var/lib/jenkins/workspace/schaer-schaer_tests_PR-462/jenkins/docker-compose.override.yml: `version` is obsolete"

Solution:
https://github.com/mailcow/mailcow-dockerized/issues/5797#issuecomment-2010649543

> Please remove the version line from the docker-compose.yml file and verify that everything still works correctly on your end. Docker has made this line obsolete, which is likely the reason you're facing this issue