### PR TITLE
Added Drush PolicyCommands

### DIFF
--- a/drush/Commands/README.md
+++ b/drush/Commands/README.md
@@ -1,0 +1,6 @@
+Drush command policies  have been implemented to prevent the execution of  certain drush commands: 'core:sync', 
+'sql:sync', and 'sql:drop' in production or other environment instances. 
+
+To apply these policies, two actions must be taken:
+- In the definition of the alias for the environment where you want these policies to be applied you have to add the parameter: "protected-instance: true"
+- On the server of the environment, copy the 'drush/Commands/drush.yml.dist' to the user's .drush folder of the user used for SSH connections to the server.

--- a/drush/Commands/drush.yml.dist
+++ b/drush/Commands/drush.yml.dist
@@ -1,0 +1,3 @@
+# This configuration file must be copied to the user's .drush folder in the environment where we want to enable
+# protection for commands that may drop or overwrite the database.
+protected-instance: true


### PR DESCRIPTION
Drush command policies  have been implemented to prevent the execution of  certain drush commands: 'core:sync', 
'sql:sync', and 'sql:drop' in production or other environment instances. 