### PR TITLE
Remove drupal-composer/drupal-security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "require": {
         "composer/installers": "^2.2",
         "cweagans/composer-patches": "^1.7",
-        "drupal-composer/drupal-security-advisories": "9.x-dev",
         "drupal/admin_toolbar": "^3.4",
         "drupal/components": "^3.0@beta",
         "drupal/config_split": "^2.0",


### PR DESCRIPTION
Remove drupal-composer/drupal-security-advisories as is not covered by the Drupal security team and the securities are covered directly with composer audit and Drupal packagist.

https://drupal.slack.com/archives/C5B7P7294/p1713987887207109